### PR TITLE
Add corpus server spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
 script:
 - bash ./corpus-client/scripts/test.sh
 - python -m unittest
-- mamba
+- env CI=travis mamba
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
 - env
 - which mamba
 - which flask
-- mamba
+- env CI=travis mamba
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
 script:
 - bash ./corpus-client/scripts/test.sh
 - python -m unittest
-- env CI=travis mamba
+- mamba
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ before_install:
 script:
 - bash ./corpus-client/scripts/test.sh
 - python -m unittest
-- env
-- which mamba
-- which flask
 - env CI=travis mamba
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
 script:
 - bash ./corpus-client/scripts/test.sh
 - python -m unittest
+- mamba
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ before_install:
 script:
 - bash ./corpus-client/scripts/test.sh
 - python -m unittest
+- env
+- which mamba
+- which flask
 - mamba
 
 notifications:

--- a/construct_mime_multipart.py
+++ b/construct_mime_multipart.py
@@ -1,0 +1,100 @@
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+import email.message
+
+import mailbox
+
+
+
+
+def message_with_plain():
+  simple = email.message.EmailMessage()
+  simple["Subject"] = "Foo Bar"
+  simple["From"] = "Foo Bar <foo@bar.com>"
+  simple["Date"] = "Tue, 01 Jan 2019 12:00:00 +0000"
+
+  simple.set_content("Hi,\n\nFirst message.\n\nRegards,\nSender")
+
+  return simple
+
+
+
+def message_with_html_and_plain():
+  html = """
+  <!DOCTYPE HTML>
+<html>
+  <body>
+    <p>Hi,</p>
+    <p>Second message.</p>
+    <p>Regards,<br/>Sender</p>
+  </body>
+</html>
+  """
+  msgText = MIMEText("Hi\n\nSecond message.\n\nRegards,\nSender")
+
+  msgHtml = MIMEText(html, 'html')
+
+  msgRelated = MIMEMultipart('related')
+  msgRelated.attach(msgHtml)
+
+  # Encapsulate the plain and HTML versions of the message body in an
+  # 'alternative' part, so message agents can decide which they want to display.
+  msgAlternative = MIMEMultipart('alternative')
+  msgAlternative.attach(msgText)
+  msgAlternative.attach(msgRelated)
+
+  # mixed
+  #   alternative
+  #     text/plain
+  #     related/
+  #        text/html
+  msgMixed = MIMEMultipart('mixed')
+  msgMixed['Subject'] = 'Foo2 Bar'
+  msgMixed['From'] = "foo2@bar.baz"
+  msgMixed['Date'] = "Tue, 01 Jan 2019 12:01:00 +0000"
+  msgMixed.attach(msgAlternative)
+
+  return msgMixed
+
+
+
+def message_with_html():
+  html = """
+<!DOCTYPE HTML>
+<html>
+  <body>
+    <p>Hi,</p>
+    <p>HTML only message.</p>
+    <p>Regards,<br/>Sender</p>
+  </body>
+</html>
+  """
+
+  msgHtml = MIMEText(html, 'html')
+
+  msgRelated = MIMEMultipart('related')
+  msgRelated.attach(msgHtml)
+
+  # mixed
+  #   alternative
+  #     text/plain
+  #     related/
+  #        text/html
+  msgMixed = MIMEMultipart('mixed')
+  msgMixed['Subject'] = 'Foo3 Bar'
+  msgMixed['From'] = "foo3@bar.baz"
+  msgMixed['Date'] = "Thu, 03 Jan 2019 12:02:00 +0000"
+  msgMixed.attach(msgRelated)
+
+  return msgMixed
+
+
+
+if __name__ == '__main__':
+  mb = mailbox.mbox("happy.mbox")
+  mb.add(message_with_plain())
+  mb.add(message_with_html_and_plain())
+  mb.add(message_with_html())
+  mb.flush()
+  mb.close()

--- a/construct_mime_multipart.py
+++ b/construct_mime_multipart.py
@@ -51,7 +51,7 @@ def message_with_html_and_plain():
   #        text/html
   msgMixed = MIMEMultipart('mixed')
   msgMixed['Subject'] = 'Foo2 Bar'
-  msgMixed['From'] = "foo2@bar.baz"
+  msgMixed['From'] = "foo2@bar.com"
   msgMixed['Date'] = "Tue, 01 Jan 2019 12:01:00 +0000"
   msgMixed.attach(msgAlternative)
 
@@ -83,7 +83,7 @@ def message_with_html():
   #        text/html
   msgMixed = MIMEMultipart('mixed')
   msgMixed['Subject'] = 'Foo3 Bar'
-  msgMixed['From'] = "foo3@bar.baz"
+  msgMixed['From'] = "foo3@baz.com"
   msgMixed['Date'] = "Thu, 03 Jan 2019 12:02:00 +0000"
   msgMixed.attach(msgRelated)
 

--- a/corpus_server.py
+++ b/corpus_server.py
@@ -4,16 +4,46 @@ import json
 
 import mailbox
 
+from os import getenv
+import os
+from os.path import abspath, dirname, isfile, join
+
 import requests
 
 import sqlite3
 
-import email_db
+from subprocess import Popen, run
 
-app = Flask(__name__, static_folder="./corpus-client/build/")
+import sys
 
-db_name = 'receipts.db'
-mbox_path = 'receipts.mbox'
+from . import email_db
+
+
+
+
+mbox_path = getenv("CORPUS_MBOX", 'receipts.mbox')
+db_path = getenv("CORPUS_MBOX", 'receipts.db')
+
+
+
+
+if not isfile(mbox_path):
+  print("no mbox at CORPUS_MBOX (%s) or CWD/receipts.mbox" % (mbox_path), file=sys.stderr)
+  sys.exit(1)
+
+
+
+
+schema_file = join(dirname(__file__), "schema.sql")
+if not isfile(db_path):
+  # create an empty file
+  run(["sqlite3", db_path, "-init", schema_file])
+
+
+
+
+static_folder = join(dirname(__file__), "corpus-client/build/")
+app = Flask(__name__, static_folder = static_folder)
 
 
 

--- a/corpus_server.py
+++ b/corpus_server.py
@@ -121,7 +121,7 @@ def email_content(sender, timestamp, content_subtype):
   mbox = mailbox.mbox(mbox_path)
 
   msg = email_db.get_message_from_mbox(mbox, sender, int(timestamp))
-  content = plaintext_payloads_of_mail(msg)
+  content = email_db.plaintext_payloads_of_mail(msg)
 
   mbox.close()
 

--- a/email_db.py
+++ b/email_db.py
@@ -128,18 +128,18 @@ def fetch_emails_info(conn, mbox):
   for row in rows:
     (res_from_email, res_date, res_timestamp, res_subject, res_note) = row
 
-    plaintext = has_plain(mbox, sender, timestamp, subject)
-    html = has_html(mbox, sender, timestamp, subject)
+    plaintext = has_plain(mbox, res_from_email, res_timestamp)
+    html = has_html(mbox, res_from_email, res_timestamp)
 
-    result << {
-       'from': res_from_email,
-       'timestamp': int(res_timestamp),
-       'datetime': res_date,
-       'subject': res_subject,
-       'plain': plaintext,
-       'html': html,
-       'note': res_note
-      }
+    result.append({
+     'from': res_from_email,
+     'timestamp': int(res_timestamp),
+     'datetime': res_date,
+     'subject': res_subject,
+     'plain': plaintext,
+     'html': html,
+     'note': res_note
+    })
 
   return result
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 expects
 flask
+ipdb
 mamba
 python-dateutil
 requests
+retrying

--- a/specs/context.py
+++ b/specs/context.py
@@ -1,0 +1,7 @@
+# Adapted from https://docs.python-guide.org/writing/structure/
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import email_db

--- a/specs/corpus_server_spec.py
+++ b/specs/corpus_server_spec.py
@@ -25,8 +25,6 @@ from tempfile import TemporaryDirectory
 
 
 
-print("PATH, in spec; %s" % os.environ["PATH"])
-
 with description('Corpus Server') as self:
   # n.b. Python/mamba doesn't allow sharing variables here?!
   with context('run in a directory with no mbox or DB'):
@@ -36,6 +34,8 @@ with description('Corpus Server') as self:
         env = {
           "FLASK_APP": flask_app,
           "PATH": os.environ["PATH"],
+          "LC_ALL": "C.UTF-8",
+          "LANG": "C.UTF-8",
         }
         if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
           env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
@@ -59,7 +59,9 @@ with description('Corpus Server') as self:
         env = {
           "FLASK_APP": flask_app,
           "CORPUS_MBOX": empty_mbox_path,
-          "PATH": os.environ["PATH"]
+          "PATH": os.environ["PATH"],
+          "LC_ALL": "C.UTF-8",
+          "LANG": "C.UTF-8",
         }
         if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
           env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
@@ -94,7 +96,9 @@ with description('Corpus Server') as self:
         env = {
           "FLASK_APP": flask_app,
           "CORPUS_MBOX": empty_mbox_path,
-          "PATH": os.environ["PATH"]
+          "PATH": os.environ["PATH"],
+          "LC_ALL": "C.UTF-8",
+          "LANG": "C.UTF-8",
         }
         if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
           env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
@@ -131,7 +135,9 @@ with description('Corpus Server') as self:
           "FLASK_APP": flask_app,
           "CORPUS_MBOX": mbox_path,
           "CORPUS_DB": db_path,
-          "PATH": os.environ["PATH"]
+          "PATH": os.environ["PATH"],
+          "LC_ALL": "C.UTF-8",
+          "LANG": "C.UTF-8",
         }
         if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
           env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
@@ -168,7 +174,9 @@ with description('Corpus Server') as self:
             "FLASK_APP": flask_app,
             "CORPUS_MBOX": mbox_path,
             "CORPUS_DB": db_path,
-            "PATH": os.environ["PATH"]
+            "PATH": os.environ["PATH"],
+            "LC_ALL": "C.UTF-8",
+            "LANG": "C.UTF-8",
           }
           if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
             env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
@@ -202,7 +210,9 @@ with description('Corpus Server') as self:
             "FLASK_APP": flask_app,
             "CORPUS_MBOX": mbox_path,
             "CORPUS_DB": db_path,
-            "PATH": os.environ["PATH"]
+            "PATH": os.environ["PATH"],
+            "LC_ALL": "C.UTF-8",
+            "LANG": "C.UTF-8",
           }
           if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
             env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
@@ -236,7 +246,9 @@ with description('Corpus Server') as self:
             "FLASK_APP": flask_app,
             "CORPUS_MBOX": mbox_path,
             "CORPUS_DB": db_path,
-            "PATH": os.environ["PATH"]
+            "PATH": os.environ["PATH"],
+            "LC_ALL": "C.UTF-8",
+            "LANG": "C.UTF-8",
           }
           if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
             env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
@@ -271,7 +283,9 @@ with description('Corpus Server') as self:
             "FLASK_APP": flask_app,
             "CORPUS_MBOX": mbox_path,
             "CORPUS_DB": db_path,
-            "PATH": os.environ["PATH"]
+            "PATH": os.environ["PATH"],
+            "LC_ALL": "C.UTF-8",
+            "LANG": "C.UTF-8",
           }
           if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
             env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
@@ -306,7 +320,9 @@ with description('Corpus Server') as self:
             "FLASK_APP": flask_app,
             "CORPUS_MBOX": mbox_path,
             "CORPUS_DB": db_path,
-            "PATH": os.environ["PATH"]
+            "PATH": os.environ["PATH"],
+            "LC_ALL": "C.UTF-8",
+            "LANG": "C.UTF-8",
           }
           if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
             env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']

--- a/specs/corpus_server_spec.py
+++ b/specs/corpus_server_spec.py
@@ -1,28 +1,22 @@
-from mamba import description, context, it
-from expects import contain, expect, equal
-
-from specs.context import email_db
-
 import json
-
 import mailbox
-
-from os.path import abspath, join
 import os
+import sqlite3
+import subprocess
+import sys
+import time
 
 import requests
 
-import sqlite3
-
-from subprocess import Popen, PIPE, TimeoutExpired
-import subprocess
-
-import sys
-
-import time
-
+from contextlib import contextmanager
+from os.path import abspath, join
+from subprocess import PIPE, Popen, TimeoutExpired
 from tempfile import TemporaryDirectory
 
+from mamba import context, description, it
+from expects import contain, equal, expect
+
+from specs.context import email_db
 
 
 with description('Corpus Server') as self:

--- a/specs/corpus_server_spec.py
+++ b/specs/corpus_server_spec.py
@@ -25,6 +25,7 @@ from tempfile import TemporaryDirectory
 
 
 
+print("PATH, in spec; %s" % os.environ["PATH"])
 
 with description('Corpus Server') as self:
   # n.b. Python/mamba doesn't allow sharing variables here?!

--- a/specs/corpus_server_spec.py
+++ b/specs/corpus_server_spec.py
@@ -19,279 +19,139 @@ from expects import contain, equal, expect
 from specs.context import email_db
 
 
+
+@contextmanager
+def corpus_server(
+  mbox_path = None,
+  db_path = None,
+  flask_app = abspath("corpus_server.py")
+):
+  with TemporaryDirectory() as tmpd:
+    if mbox_path is None:
+      mbox_path = join(tmpd, "empty.mbox")
+      mbox = mailbox.mbox(mbox_path)
+      mbox.close()
+    if db_path is None:
+      db_path = join(tmpd, "test.db")
+    env = {
+      "FLASK_APP": flask_app,
+      "CORPUS_MBOX": mbox_path,
+      "CORPUS_DB": db_path,
+      "PATH": os.environ["PATH"],
+      "LC_ALL": "C.UTF-8",
+      "LANG": "C.UTF-8",
+    }
+    if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
+      env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
+
+    try:
+      server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
+
+      # Wait for Server to be ready
+      # XXX
+      if os.environ.get("CI"):
+        time.sleep(5)
+
+      info = {
+        "proc": server,
+        "port": 5000,
+        "tmpd": tmpd,
+      }
+      yield info
+    except AssertionError:
+      print("Assertion failed in ctx mgr")
+      print("server STDOUT:")
+      print(server.stdout.decode("unicode_escape"))
+      print("server STDERR:")
+      print(server.stderr.decode("unicode_escape"))
+      raise
+    finally:
+      server.kill()
+      outs, errs = server.communicate()
+
+
+
+
 with description('Corpus Server') as self:
   # n.b. Python/mamba doesn't allow sharing variables here?!
   with context('run in a directory with no mbox or DB'):
     with it('fails to run the server'):
-      with TemporaryDirectory() as tmpd:
-        flask_app = abspath("corpus_server.py")
-        env = {
-          "FLASK_APP": flask_app,
-          "PATH": os.environ["PATH"],
-          "LC_ALL": "C.UTF-8",
-          "LANG": "C.UTF-8",
-        }
-        if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
-          env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
-        server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout=PIPE, stderr = PIPE)
-
-        if os.environ.get("CI"):
-          time.sleep(5)
-
-        poll = server.wait(timeout=30)
-        outs, errs = server.communicate()
+      with corpus_server(mbox_path = "nonexistant.mbox") as server_info:
+        poll = server_info["proc"].wait(timeout=30)
 
         expect(poll).to(equal(1))
 
+
+
   with context('run in a directory with an empty mbox, but no DB'):
     with it('is able to return /status successfully'):
-      with TemporaryDirectory() as tmpd:
-        flask_app = abspath("corpus_server.py")
-        empty_mbox_path = join(tmpd, "empty.mbox")
-        empty_mbox = mailbox.mbox(empty_mbox_path)
-        empty_mbox.close()
-        env = {
-          "FLASK_APP": flask_app,
-          "CORPUS_MBOX": empty_mbox_path,
-          "PATH": os.environ["PATH"],
-          "LC_ALL": "C.UTF-8",
-          "LANG": "C.UTF-8",
-        }
-        if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
-          env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
+      with corpus_server() as server_info:
+        response = requests.get("http://localhost:5000/status")
+        expect(response.status_code).to(equal(200))
 
-        # response = requests.get("http://localhost:5000/status")
-        # expect(response.status_code).to(equal(200))
-        try:
-          server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
-
-          if os.environ.get("CI"):
-            time.sleep(5)
-
-          response = requests.get("http://localhost:5000/status")
-          expect(response.status_code).to(equal(200))
-
-        finally:
-          server.kill()
-          outs, errs = server.communicate()
 
     with it('is able to return /api/emails successfully with empty result'):
-      with TemporaryDirectory() as tmpd:
-        flask_app = abspath("corpus_server.py")
-        empty_mbox_path = join(tmpd, "empty.mbox")
-        empty_mbox = mailbox.mbox(empty_mbox_path)
-        empty_mbox.close()
-        env = {
-          "FLASK_APP": flask_app,
-          "CORPUS_MBOX": empty_mbox_path,
-          "PATH": os.environ["PATH"],
-          "LC_ALL": "C.UTF-8",
-          "LANG": "C.UTF-8",
-        }
-        if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
-          env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
+      with corpus_server() as server_info:
+        response = requests.get("http://localhost:5000/api/emails")
+        expect(response.status_code).to(equal(200))
 
-        try:
-          server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
+        data = json.loads(response.text)
+        expect(len(data["emails"])).to(equal(0))
 
-          if os.environ.get("CI"):
-            time.sleep(5)
 
-          response = requests.get("http://localhost:5000/api/emails")
-          expect(response.status_code).to(equal(200))
-
-          data = json.loads(response.text)
-          expect(len(data["emails"])).to(equal(0))
-
-        finally:
-          server.kill()
-          outs, errs = server.communicate()
 
   with context('run with specs/happy.mbox, but no DB'):
     with it('is able to return /api/emails successfully with 3 results'):
-      with TemporaryDirectory() as tmpd:
-        flask_app = abspath("corpus_server.py")
-        mbox_path = abspath("specs/happy.mbox")
-        db_path = join(tmpd, "test.db")
-        env = {
-          "FLASK_APP": flask_app,
-          "CORPUS_MBOX": mbox_path,
-          "CORPUS_DB": db_path,
-          "PATH": os.environ["PATH"],
-          "LC_ALL": "C.UTF-8",
-          "LANG": "C.UTF-8",
-        }
-        if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
-          env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
+      mbox_path = abspath("specs/happy.mbox")
+      with corpus_server(mbox_path = mbox_path) as server_info:
+        response = requests.get("http://localhost:5000/api/emails")
+        expect(response.status_code).to(equal(200))
 
-        try:
-          server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
-
-          if os.environ.get("CI"):
-            time.sleep(5)
-
-          response = requests.get("http://localhost:5000/api/emails")
-          expect(response.status_code).to(equal(200))
-
-          data = json.loads(response.text)
-          expect(len(data["emails"])).to(equal(3))
-
-        finally:
-          server.kill()
-          outs, errs = server.communicate()
+        data = json.loads(response.text)
+        expect(len(data["emails"])).to(equal(3))
 
     with context('/api/email/<sender>/<timestamp>/<content>'):
       with it('/api/email/foo@bar.com/1546344000/plain'):
-        with TemporaryDirectory() as tmpd:
-          flask_app = abspath("corpus_server.py")
-          mbox_path = abspath("specs/happy.mbox")
-          db_path = join(tmpd, "test.db")
-          env = {
-            "FLASK_APP": flask_app,
-            "CORPUS_MBOX": mbox_path,
-            "CORPUS_DB": db_path,
-            "PATH": os.environ["PATH"],
-            "LC_ALL": "C.UTF-8",
-            "LANG": "C.UTF-8",
-          }
-          if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
-            env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
-
-          try:
-            server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
-
-            if os.environ.get("CI"):
-              time.sleep(5)
-
+        mbox_path = abspath("specs/happy.mbox")
+        with corpus_server(mbox_path = mbox_path) as server_info:
             response = requests.get("http://localhost:5000/api/email/foo@bar.com/1546344000/plain")
             expect(response.status_code).to(equal(200))
 
             expect(response.text).to(contain("First message."))
-          finally:
-            server.kill()
-            outs, errs = server.communicate()
 
       with it('/api/email/foo2@bar.com/1546344060/plain'):
-        with TemporaryDirectory() as tmpd:
-          flask_app = abspath("corpus_server.py")
-          mbox_path = abspath("specs/happy.mbox")
-          db_path = join(tmpd, "test.db")
-          env = {
-            "FLASK_APP": flask_app,
-            "CORPUS_MBOX": mbox_path,
-            "CORPUS_DB": db_path,
-            "PATH": os.environ["PATH"],
-            "LC_ALL": "C.UTF-8",
-            "LANG": "C.UTF-8",
-          }
-          if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
-            env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
+        mbox_path = abspath("specs/happy.mbox")
+        with corpus_server(mbox_path = mbox_path) as server_info:
+          response = requests.get("http://localhost:5000/api/email/foo2@bar.com/1546344060/plain")
+          expect(response.status_code).to(equal(200))
 
-          try:
-            server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
-
-            if os.environ.get("CI"):
-              time.sleep(5)
-
-            response = requests.get("http://localhost:5000/api/email/foo2@bar.com/1546344060/plain")
-            expect(response.status_code).to(equal(200))
-
-            expect(response.text).to(contain("Second message."))
-          finally:
-            server.kill()
-            outs, errs = server.communicate()
+          expect(response.text).to(contain("Second message."))
 
       with it('/api/email/foo2@bar.com/1546344060/html'):
-        with TemporaryDirectory() as tmpd:
-          flask_app = abspath("corpus_server.py")
-          mbox_path = abspath("specs/happy.mbox")
-          db_path = join(tmpd, "test.db")
-          env = {
-            "FLASK_APP": flask_app,
-            "CORPUS_MBOX": mbox_path,
-            "CORPUS_DB": db_path,
-            "PATH": os.environ["PATH"],
-            "LC_ALL": "C.UTF-8",
-            "LANG": "C.UTF-8",
-          }
-          if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
-            env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
+        mbox_path = abspath("specs/happy.mbox")
+        with corpus_server(mbox_path = mbox_path) as server_info:
+          response = requests.get("http://localhost:5000/api/email/foo2@bar.com/1546344060/html")
+          expect(response.status_code).to(equal(200))
 
-          try:
-            server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
-
-            if os.environ.get("CI"):
-              time.sleep(5)
-
-            response = requests.get("http://localhost:5000/api/email/foo2@bar.com/1546344060/html")
-            expect(response.status_code).to(equal(200))
-
-            expect(response.text).to(contain("Second message."))
-            expect(response.text).to(contain("<p>"))
-          finally:
-            server.kill()
-            outs, errs = server.communicate()
+          expect(response.text).to(contain("Second message."))
+          expect(response.text).to(contain("<p>"))
 
       with it('/api/email/foo3@baz.com/1546516920/html'):
-        with TemporaryDirectory() as tmpd:
-          flask_app = abspath("corpus_server.py")
-          mbox_path = abspath("specs/happy.mbox")
-          db_path = join(tmpd, "test.db")
-          env = {
-            "FLASK_APP": flask_app,
-            "CORPUS_MBOX": mbox_path,
-            "CORPUS_DB": db_path,
-            "PATH": os.environ["PATH"],
-            "LC_ALL": "C.UTF-8",
-            "LANG": "C.UTF-8",
-          }
-          if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
-            env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
+        mbox_path = abspath("specs/happy.mbox")
+        with corpus_server(mbox_path = mbox_path) as server_info:
+          response = requests.get("http://localhost:5000/api/email/foo3@baz.com/1546516920/html")
+          expect(response.status_code).to(equal(200))
 
-          try:
-            server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
-
-            if os.environ.get("CI"):
-              time.sleep(5)
-
-            response = requests.get("http://localhost:5000/api/email/foo3@baz.com/1546516920/html")
-            expect(response.status_code).to(equal(200))
-
-            expect(response.text).to(contain("HTML only message."))
-          finally:
-            server.kill()
-            outs, errs = server.communicate()
+          expect(response.text).to(contain("HTML only message."))
 
     if sqlite3.sqlite_version >= "3.24":
       with it('PATCH /api/email/foo@bar.com/1546344000/plain'):
-        with TemporaryDirectory() as tmpd:
-          flask_app = abspath("corpus_server.py")
-          mbox_path = abspath("specs/happy.mbox")
-          db_path = join(tmpd, "test.db")
-          env = {
-            "FLASK_APP": flask_app,
-            "CORPUS_MBOX": mbox_path,
-            "CORPUS_DB": db_path,
-            "PATH": os.environ["PATH"],
-            "LC_ALL": "C.UTF-8",
-            "LANG": "C.UTF-8",
-          }
-          if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
-            env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
+        mbox_path = abspath("specs/happy.mbox")
+        with corpus_server(mbox_path = mbox_path) as server_info:
+          req_data = json.dumps({
+            "note": "updated note"
+          })
+          response = requests.patch("http://localhost:5000/api/email/foo@bar.com/1546344000", data = req_data)
+          expect(response.status_code).to(equal(200))
 
-          try:
-            server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
-
-            if os.environ.get("CI"):
-              time.sleep(5)
-
-            req_data = json.dumps({
-              "note": "updated note"
-            })
-            response = requests.patch("http://localhost:5000/api/email/foo@bar.com/1546344000", data = req_data)
-            expect(response.status_code).to(equal(200))
-
-            expect(response.text).to(contain("updated"))
-          finally:
-            server.kill()
-            outs, errs = server.communicate()
+          expect(response.text).to(contain("updated"))

--- a/specs/corpus_server_spec.py
+++ b/specs/corpus_server_spec.py
@@ -78,6 +78,12 @@ with description('Corpus Server') as self:
         finally:
           server.kill()
           outs, errs = server.communicate()
+          if outs:
+            print("outs:")
+            print(outs)
+          if errs:
+            print("errs:")
+            print(errs)
 
     with it('is able to return /api/emails successfully with empty result'):
       with TemporaryDirectory() as tmpd:
@@ -108,6 +114,12 @@ with description('Corpus Server') as self:
         finally:
           server.kill()
           outs, errs = server.communicate()
+          if outs:
+            print("outs:")
+            print(outs)
+          if errs:
+            print("errs:")
+            print(errs)
 
   with context('run with specs/happy.mbox, but no DB'):
     with it('is able to return /api/emails successfully with 3 results'):
@@ -139,6 +151,12 @@ with description('Corpus Server') as self:
         finally:
           server.kill()
           outs, errs = server.communicate()
+          if outs:
+            print("outs:")
+            print(outs)
+          if errs:
+            print("errs:")
+            print(errs)
 
     with context('/api/email/<sender>/<timestamp>/<content>'):
       with it('/api/email/foo@bar.com/1546344000/plain'):
@@ -168,6 +186,12 @@ with description('Corpus Server') as self:
           finally:
             server.kill()
             outs, errs = server.communicate()
+            if outs:
+              print("outs:")
+              print(outs)
+            if errs:
+              print("errs:")
+              print(errs)
 
       with it('/api/email/foo2@bar.com/1546344060/plain'):
         with TemporaryDirectory() as tmpd:
@@ -196,6 +220,12 @@ with description('Corpus Server') as self:
           finally:
             server.kill()
             outs, errs = server.communicate()
+            if outs:
+              print("outs:")
+              print(outs)
+            if errs:
+              print("errs:")
+              print(errs)
 
       with it('/api/email/foo2@bar.com/1546344060/html'):
         with TemporaryDirectory() as tmpd:
@@ -225,6 +255,12 @@ with description('Corpus Server') as self:
           finally:
             server.kill()
             outs, errs = server.communicate()
+            if outs:
+              print("outs:")
+              print(outs)
+            if errs:
+              print("errs:")
+              print(errs)
 
       with it('/api/email/foo3@baz.com/1546516920/html'):
         with TemporaryDirectory() as tmpd:
@@ -253,6 +289,12 @@ with description('Corpus Server') as self:
           finally:
             server.kill()
             outs, errs = server.communicate()
+            if outs:
+              print("outs:")
+              print(outs)
+            if errs:
+              print("errs:")
+              print(errs)
 
     if sqlite3.sqlite_version >= "3.24":
       with it('PATCH /api/email/foo@bar.com/1546344000/plain'):
@@ -285,3 +327,9 @@ with description('Corpus Server') as self:
           finally:
             server.kill()
             outs, errs = server.communicate()
+            if outs:
+              print("outs:")
+              print(outs)
+            if errs:
+              print("errs:")
+              print(errs)

--- a/specs/corpus_server_spec.py
+++ b/specs/corpus_server_spec.py
@@ -41,6 +41,9 @@ with description('Corpus Server') as self:
           env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
         server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout=PIPE, stderr = PIPE)
 
+        if os.environ.get("CI"):
+          time.sleep(5)
+
         poll = server.wait(timeout=30)
         outs, errs = server.communicate()
 
@@ -66,6 +69,9 @@ with description('Corpus Server') as self:
         try:
           server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
 
+          if os.environ.get("CI"):
+            time.sleep(5)
+
           response = requests.get("http://localhost:5000/status")
           expect(response.status_code).to(equal(200))
 
@@ -89,6 +95,9 @@ with description('Corpus Server') as self:
 
         try:
           server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
+
+          if os.environ.get("CI"):
+            time.sleep(5)
 
           response = requests.get("http://localhost:5000/api/emails")
           expect(response.status_code).to(equal(200))
@@ -118,6 +127,9 @@ with description('Corpus Server') as self:
         try:
           server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
 
+          if os.environ.get("CI"):
+            time.sleep(5)
+
           response = requests.get("http://localhost:5000/api/emails")
           expect(response.status_code).to(equal(200))
 
@@ -146,6 +158,9 @@ with description('Corpus Server') as self:
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
 
+            if os.environ.get("CI"):
+              time.sleep(5)
+
             response = requests.get("http://localhost:5000/api/email/foo@bar.com/1546344000/plain")
             expect(response.status_code).to(equal(200))
 
@@ -171,6 +186,9 @@ with description('Corpus Server') as self:
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
 
+            if os.environ.get("CI"):
+              time.sleep(5)
+
             response = requests.get("http://localhost:5000/api/email/foo2@bar.com/1546344060/plain")
             expect(response.status_code).to(equal(200))
 
@@ -195,6 +213,9 @@ with description('Corpus Server') as self:
 
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
+
+            if os.environ.get("CI"):
+              time.sleep(5)
 
             response = requests.get("http://localhost:5000/api/email/foo2@bar.com/1546344060/html")
             expect(response.status_code).to(equal(200))
@@ -222,6 +243,9 @@ with description('Corpus Server') as self:
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
 
+            if os.environ.get("CI"):
+              time.sleep(5)
+
             response = requests.get("http://localhost:5000/api/email/foo3@baz.com/1546516920/html")
             expect(response.status_code).to(equal(200))
 
@@ -247,6 +271,9 @@ with description('Corpus Server') as self:
 
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
+
+            if os.environ.get("CI"):
+              time.sleep(5)
 
             req_data = json.dumps({
               "note": "updated note"

--- a/specs/corpus_server_spec.py
+++ b/specs/corpus_server_spec.py
@@ -1,0 +1,61 @@
+from mamba import description, context, it
+from expects import expect, equal
+
+from specs.context import email_db
+
+import mailbox
+
+from os.path import abspath, join
+import os
+
+import requests
+
+from subprocess import Popen, PIPE, TimeoutExpired
+import subprocess
+
+import sys
+
+from tempfile import TemporaryDirectory
+
+
+
+
+with description('Corpus Server') as self:
+  # n.b. Python/mamba doesn't allow sharing variables here?!
+  with context('run in a directory with no mbox or DB'):
+    with it('fails to run the server'):
+      with TemporaryDirectory() as tmpd:
+        flask_app = abspath("corpus_server.py")
+        env = {
+          "FLASK_APP": flask_app,
+        }
+        if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
+          env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
+        server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout=PIPE, stderr = PIPE)
+
+        poll = server.wait(timeout=30)
+        outs, errs = server.communicate()
+
+        expect(poll).to(equal(1))
+
+  with context('run in a directory with an empty mbox, but no DB'):
+    with it('is able to return /status successfully'):
+      with TemporaryDirectory() as tmpd:
+        flask_app = abspath("corpus_server.py")
+        empty_mbox_path = join(tmpd, "empty.mbox")
+        empty_mbox = mailbox.mbox(empty_mbox_path)
+        empty_mbox.close()
+        env = {
+          "FLASK_APP": flask_app,
+          "CORPUS_MBOX": empty_mbox_path,
+        }
+        if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
+          env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
+
+        server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
+
+        response = requests.get("http://localhost:5000/status")
+        expect(response.status_code).to(equal(200))
+
+        server.kill()
+        outs, errs = server.communicate()

--- a/specs/corpus_server_spec.py
+++ b/specs/corpus_server_spec.py
@@ -19,6 +19,8 @@ import subprocess
 
 import sys
 
+import time
+
 from tempfile import TemporaryDirectory
 
 
@@ -38,6 +40,9 @@ with description('Corpus Server') as self:
         if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
           env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
         server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout=PIPE, stderr = PIPE)
+
+        if os.environ.get("CI"):
+          time.sleep(5)
 
         poll = server.wait(timeout=30)
         outs, errs = server.communicate()
@@ -65,6 +70,9 @@ with description('Corpus Server') as self:
         # expect(response.status_code).to(equal(200))
         try:
           server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
+
+          if os.environ.get("CI"):
+            time.sleep(5)
 
           response = requests.get("http://localhost:5000/status")
           expect(response.status_code).to(equal(200))
@@ -97,6 +105,9 @@ with description('Corpus Server') as self:
 
         try:
           server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
+
+          if os.environ.get("CI"):
+            time.sleep(5)
 
           response = requests.get("http://localhost:5000/api/emails")
           expect(response.status_code).to(equal(200))
@@ -134,6 +145,9 @@ with description('Corpus Server') as self:
         try:
           server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
 
+          if os.environ.get("CI"):
+            time.sleep(5)
+
           response = requests.get("http://localhost:5000/api/emails")
           expect(response.status_code).to(equal(200))
 
@@ -170,6 +184,9 @@ with description('Corpus Server') as self:
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
 
+            if os.environ.get("CI"):
+              time.sleep(5)
+
             response = requests.get("http://localhost:5000/api/email/foo@bar.com/1546344000/plain")
             expect(response.status_code).to(equal(200))
 
@@ -203,6 +220,9 @@ with description('Corpus Server') as self:
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
 
+            if os.environ.get("CI"):
+              time.sleep(5)
+
             response = requests.get("http://localhost:5000/api/email/foo2@bar.com/1546344060/plain")
             expect(response.status_code).to(equal(200))
 
@@ -235,6 +255,9 @@ with description('Corpus Server') as self:
 
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
+
+            if os.environ.get("CI"):
+              time.sleep(5)
 
             response = requests.get("http://localhost:5000/api/email/foo2@bar.com/1546344060/html")
             expect(response.status_code).to(equal(200))
@@ -270,6 +293,9 @@ with description('Corpus Server') as self:
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
 
+            if os.environ.get("CI"):
+              time.sleep(5)
+
             response = requests.get("http://localhost:5000/api/email/foo3@baz.com/1546516920/html")
             expect(response.status_code).to(equal(200))
 
@@ -303,6 +329,9 @@ with description('Corpus Server') as self:
 
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
+
+            if os.environ.get("CI"):
+              time.sleep(5)
 
             req_data = json.dumps({
               "note": "updated note"

--- a/specs/corpus_server_spec.py
+++ b/specs/corpus_server_spec.py
@@ -124,3 +124,104 @@ with description('Corpus Server') as self:
         finally:
           server.kill()
           outs, errs = server.communicate()
+
+    with context('/api/email/<sender>/<timestamp>/<content>'):
+      with it('/api/email/foo@bar.com/1546344000/plain'):
+        with TemporaryDirectory() as tmpd:
+          flask_app = abspath("corpus_server.py")
+          mbox_path = abspath("specs/happy.mbox")
+          db_path = join(tmpd, "test.db")
+          env = {
+            "FLASK_APP": flask_app,
+            "CORPUS_MBOX": mbox_path,
+            "CORPUS_DB": db_path,
+            "PATH": os.environ["PATH"]
+          }
+          if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
+            env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
+
+          try:
+            server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
+
+            response = requests.get("http://localhost:5000/api/email/foo@bar.com/1546344000/plain")
+            expect(response.status_code).to(equal(200))
+
+            # XXX assert text contents
+          finally:
+            server.kill()
+            outs, errs = server.communicate()
+
+      with it('/api/email/foo2@bar.com/1546344060/plain'):
+        with TemporaryDirectory() as tmpd:
+          flask_app = abspath("corpus_server.py")
+          mbox_path = abspath("specs/happy.mbox")
+          db_path = join(tmpd, "test.db")
+          env = {
+            "FLASK_APP": flask_app,
+            "CORPUS_MBOX": mbox_path,
+            "CORPUS_DB": db_path,
+            "PATH": os.environ["PATH"]
+          }
+          if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
+            env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
+
+          try:
+            server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
+
+            response = requests.get("http://localhost:5000/api/email/foo2@bar.com/1546344060/plain")
+            expect(response.status_code).to(equal(200))
+
+            # XXX assert text contents
+          finally:
+            server.kill()
+            outs, errs = server.communicate()
+
+      with it('/api/email/foo2@bar.com/1546344060/html'):
+        with TemporaryDirectory() as tmpd:
+          flask_app = abspath("corpus_server.py")
+          mbox_path = abspath("specs/happy.mbox")
+          db_path = join(tmpd, "test.db")
+          env = {
+            "FLASK_APP": flask_app,
+            "CORPUS_MBOX": mbox_path,
+            "CORPUS_DB": db_path,
+            "PATH": os.environ["PATH"]
+          }
+          if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
+            env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
+
+          try:
+            server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
+
+            response = requests.get("http://localhost:5000/api/email/foo2@bar.com/1546344060/html")
+            expect(response.status_code).to(equal(200))
+
+            # XXX assert text contents
+          finally:
+            server.kill()
+            outs, errs = server.communicate()
+
+      with it('/api/email/foo3@baz.com/1546516920/html'):
+        with TemporaryDirectory() as tmpd:
+          flask_app = abspath("corpus_server.py")
+          mbox_path = abspath("specs/happy.mbox")
+          db_path = join(tmpd, "test.db")
+          env = {
+            "FLASK_APP": flask_app,
+            "CORPUS_MBOX": mbox_path,
+            "CORPUS_DB": db_path,
+            "PATH": os.environ["PATH"]
+          }
+          if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
+            env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
+
+          try:
+            server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
+
+            response = requests.get("http://localhost:5000/api/email/foo3@baz.com/1546516920/html")
+            expect(response.status_code).to(equal(200))
+
+            # XXX assert text contents
+          finally:
+            server.kill()
+            outs, errs = server.communicate()

--- a/specs/corpus_server_spec.py
+++ b/specs/corpus_server_spec.py
@@ -19,8 +19,6 @@ import subprocess
 
 import sys
 
-import time
-
 from tempfile import TemporaryDirectory
 
 
@@ -40,9 +38,6 @@ with description('Corpus Server') as self:
         if 'SYSTEMROOT' in os.environ:  # Windows http://bugs.python.org/issue20614
           env[str('SYSTEMROOT')] = os.environ['SYSTEMROOT']
         server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout=PIPE, stderr = PIPE)
-
-        if os.environ.get("CI"):
-          time.sleep(5)
 
         poll = server.wait(timeout=30)
         outs, errs = server.communicate()
@@ -70,9 +65,6 @@ with description('Corpus Server') as self:
         # expect(response.status_code).to(equal(200))
         try:
           server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
-
-          if os.environ.get("CI"):
-            time.sleep(5)
 
           response = requests.get("http://localhost:5000/status")
           expect(response.status_code).to(equal(200))
@@ -105,9 +97,6 @@ with description('Corpus Server') as self:
 
         try:
           server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
-
-          if os.environ.get("CI"):
-            time.sleep(5)
 
           response = requests.get("http://localhost:5000/api/emails")
           expect(response.status_code).to(equal(200))
@@ -145,9 +134,6 @@ with description('Corpus Server') as self:
         try:
           server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
 
-          if os.environ.get("CI"):
-            time.sleep(5)
-
           response = requests.get("http://localhost:5000/api/emails")
           expect(response.status_code).to(equal(200))
 
@@ -184,9 +170,6 @@ with description('Corpus Server') as self:
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
 
-            if os.environ.get("CI"):
-              time.sleep(5)
-
             response = requests.get("http://localhost:5000/api/email/foo@bar.com/1546344000/plain")
             expect(response.status_code).to(equal(200))
 
@@ -220,9 +203,6 @@ with description('Corpus Server') as self:
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
 
-            if os.environ.get("CI"):
-              time.sleep(5)
-
             response = requests.get("http://localhost:5000/api/email/foo2@bar.com/1546344060/plain")
             expect(response.status_code).to(equal(200))
 
@@ -255,9 +235,6 @@ with description('Corpus Server') as self:
 
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
-
-            if os.environ.get("CI"):
-              time.sleep(5)
 
             response = requests.get("http://localhost:5000/api/email/foo2@bar.com/1546344060/html")
             expect(response.status_code).to(equal(200))
@@ -293,9 +270,6 @@ with description('Corpus Server') as self:
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
 
-            if os.environ.get("CI"):
-              time.sleep(5)
-
             response = requests.get("http://localhost:5000/api/email/foo3@baz.com/1546516920/html")
             expect(response.status_code).to(equal(200))
 
@@ -329,9 +303,6 @@ with description('Corpus Server') as self:
 
           try:
             server = Popen(["flask", "run"], cwd = tmpd, env = env, stdout = PIPE, stderr = PIPE)
-
-            if os.environ.get("CI"):
-              time.sleep(5)
 
             req_data = json.dumps({
               "note": "updated note"

--- a/specs/corpus_server_spec.py
+++ b/specs/corpus_server_spec.py
@@ -80,12 +80,6 @@ with description('Corpus Server') as self:
         finally:
           server.kill()
           outs, errs = server.communicate()
-          if outs:
-            print("outs:")
-            print(outs)
-          if errs:
-            print("errs:")
-            print(errs)
 
     with it('is able to return /api/emails successfully with empty result'):
       with TemporaryDirectory() as tmpd:
@@ -118,12 +112,6 @@ with description('Corpus Server') as self:
         finally:
           server.kill()
           outs, errs = server.communicate()
-          if outs:
-            print("outs:")
-            print(outs)
-          if errs:
-            print("errs:")
-            print(errs)
 
   with context('run with specs/happy.mbox, but no DB'):
     with it('is able to return /api/emails successfully with 3 results'):
@@ -157,12 +145,6 @@ with description('Corpus Server') as self:
         finally:
           server.kill()
           outs, errs = server.communicate()
-          if outs:
-            print("outs:")
-            print(outs)
-          if errs:
-            print("errs:")
-            print(errs)
 
     with context('/api/email/<sender>/<timestamp>/<content>'):
       with it('/api/email/foo@bar.com/1546344000/plain'):
@@ -194,12 +176,6 @@ with description('Corpus Server') as self:
           finally:
             server.kill()
             outs, errs = server.communicate()
-            if outs:
-              print("outs:")
-              print(outs)
-            if errs:
-              print("errs:")
-              print(errs)
 
       with it('/api/email/foo2@bar.com/1546344060/plain'):
         with TemporaryDirectory() as tmpd:
@@ -230,12 +206,6 @@ with description('Corpus Server') as self:
           finally:
             server.kill()
             outs, errs = server.communicate()
-            if outs:
-              print("outs:")
-              print(outs)
-            if errs:
-              print("errs:")
-              print(errs)
 
       with it('/api/email/foo2@bar.com/1546344060/html'):
         with TemporaryDirectory() as tmpd:
@@ -267,12 +237,6 @@ with description('Corpus Server') as self:
           finally:
             server.kill()
             outs, errs = server.communicate()
-            if outs:
-              print("outs:")
-              print(outs)
-            if errs:
-              print("errs:")
-              print(errs)
 
       with it('/api/email/foo3@baz.com/1546516920/html'):
         with TemporaryDirectory() as tmpd:
@@ -303,12 +267,6 @@ with description('Corpus Server') as self:
           finally:
             server.kill()
             outs, errs = server.communicate()
-            if outs:
-              print("outs:")
-              print(outs)
-            if errs:
-              print("errs:")
-              print(errs)
 
     if sqlite3.sqlite_version >= "3.24":
       with it('PATCH /api/email/foo@bar.com/1546344000/plain'):
@@ -343,9 +301,3 @@ with description('Corpus Server') as self:
           finally:
             server.kill()
             outs, errs = server.communicate()
-            if outs:
-              print("outs:")
-              print(outs)
-            if errs:
-              print("errs:")
-              print(errs)

--- a/specs/happy.mbox
+++ b/specs/happy.mbox
@@ -17,7 +17,7 @@ From MAILER-DAEMON Wed Feb 12 11:54:32 2020
 Content-Type: multipart/mixed; boundary="===============1602477251998784918=="
 MIME-Version: 1.0
 Subject: Foo2 Bar
-From: foo2@bar.baz
+From: foo2@bar.com
 Date: Tue, 01 Jan 2019 12:01:00 +0000
 
 --===============1602477251998784918==
@@ -64,7 +64,7 @@ From MAILER-DAEMON Wed Feb 12 11:54:32 2020
 Content-Type: multipart/mixed; boundary="===============1540831233228776225=="
 MIME-Version: 1.0
 Subject: Foo3 Bar
-From: foo3@bar.baz
+From: foo3@baz.com
 Date: Thu, 03 Jan 2019 12:02:00 +0000
 
 --===============1540831233228776225==

--- a/specs/happy.mbox
+++ b/specs/happy.mbox
@@ -1,0 +1,92 @@
+From MAILER-DAEMON Wed Feb 12 11:54:32 2020
+Subject: Foo Bar
+From: Foo Bar <foo@bar.com>
+Date: Tue, 01 Jan 2019 12:00:00 +0000
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+
+Hi,
+
+First message.
+
+Regards,
+Sender
+
+From MAILER-DAEMON Wed Feb 12 11:54:32 2020
+Content-Type: multipart/mixed; boundary="===============1602477251998784918=="
+MIME-Version: 1.0
+Subject: Foo2 Bar
+From: foo2@bar.baz
+Date: Tue, 01 Jan 2019 12:01:00 +0000
+
+--===============1602477251998784918==
+Content-Type: multipart/alternative; boundary="===============0498442328371279220=="
+MIME-Version: 1.0
+
+--===============0498442328371279220==
+Content-Type: text/plain; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+
+Hi
+
+Second message.
+
+Regards,
+Sender
+--===============0498442328371279220==
+Content-Type: multipart/related; boundary="===============8901468107136605347=="
+MIME-Version: 1.0
+
+--===============8901468107136605347==
+Content-Type: text/html; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+
+
+  <!DOCTYPE HTML>
+<html>
+  <body>
+    <p>Hi,</p>
+    <p>Second message.</p>
+    <p>Regards,<br/>Sender</p>
+  </body>
+</html>
+  
+--===============8901468107136605347==--
+
+--===============0498442328371279220==--
+
+--===============1602477251998784918==--
+
+From MAILER-DAEMON Wed Feb 12 11:54:32 2020
+Content-Type: multipart/mixed; boundary="===============1540831233228776225=="
+MIME-Version: 1.0
+Subject: Foo3 Bar
+From: foo3@bar.baz
+Date: Thu, 03 Jan 2019 12:02:00 +0000
+
+--===============1540831233228776225==
+Content-Type: multipart/related; boundary="===============0208093545728246674=="
+MIME-Version: 1.0
+
+--===============0208093545728246674==
+Content-Type: text/html; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+
+
+<!DOCTYPE HTML>
+<html>
+  <body>
+    <p>Hi,</p>
+    <p>HTML only message.</p>
+    <p>Regards,<br/>Sender</p>
+  </body>
+</html>
+  
+--===============0208093545728246674==--
+
+--===============1540831233228776225==--
+


### PR DESCRIPTION
#1 had added a `corpus_server.py` but hadn't added a component spec for it.

This PR adds the component spec, which should make it easier to test when extending functionality.